### PR TITLE
fix(typescript): fix initializer error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
-export const GLIBC: string = 'glibc';
-export const MUSL: string = 'musl';
+export const GLIBC: 'glibc';
+export const MUSL: 'musl';
 
 export function family(): Promise<string | null>;
 export function familySync(): string | null;


### PR DESCRIPTION
I'm trying to upgrade `detect-libc` to `^2.0.0` in `electron-rebuild` (written in TypeScript) and I'm getting the [following error](https://app.circleci.com/pipelines/github/electron/electron-rebuild/1362/workflows/73dfa249-5e4c-438c-8877-197b159847f3/jobs/6900?invite=true#step-104-16):

```
> tsc

node_modules/detect-libc/index.d.ts:1:30 - error TS1039: Initializers are not allowed in ambient contexts.

1 export const GLIBC: string = 'glibc';
                               ~~~~~~~

node_modules/detect-libc/index.d.ts:2:29 - error TS1039: Initializers are not allowed in ambient contexts.

2 export const MUSL: string = 'musl';
                              ~~~~~~


Found 2 errors.

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

Exited with code exit status 2
```

I fixed it by effectively copying the [DefinitelyTyped `@types/detect-libc` version](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ea0e0de908b17dd697e373da9cd0fca8d7e41c66/types/detect-libc/index.d.ts#L6-L7). (Tested locally by editing the `index.d.ts` file in `node_modules`.)

----

It might be helpful in the future to avoid these kinds of errors by utilizing a typings checker such as [`tsd`](https://github.com/SamVerschueren/tsd).