### PR TITLE
fix: improve performance of `getReport()`

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -8,10 +8,14 @@ const isLinux = () => process.platform === 'linux';
 let report = null;
 const getReport = () => {
   if (!report) {
-    /* istanbul ignore next */
-    report = isLinux() && process.report
-      ? process.report.getReport()
-      : {};
+    if (isLinux() && process.report) {
+      const orig = process.report.excludeNetwork;
+      process.report.excludeNetwork = true;
+      report = process.report.getReport();
+      process.report.excludeNetwork = orig;
+    } else {
+      report = {};
+    }
   }
   return report;
 };

--- a/lib/process.js
+++ b/lib/process.js
@@ -14,6 +14,7 @@ const getReport = () => {
       report = process.report.getReport();
       process.report.excludeNetwork = orig;
     } else {
+      /* istanbul ignore next */
       report = {};
     }
   }

--- a/lib/process.js
+++ b/lib/process.js
@@ -8,13 +8,13 @@ const isLinux = () => process.platform === 'linux';
 let report = null;
 const getReport = () => {
   if (!report) {
+    /* istanbul ignore next */
     if (isLinux() && process.report) {
       const orig = process.report.excludeNetwork;
       process.report.excludeNetwork = true;
       report = process.report.getReport();
       process.report.excludeNetwork = orig;
     } else {
-      /* istanbul ignore next */
       report = {};
     }
   }


### PR DESCRIPTION
This will improve performance for newer versions of Node.js because this report doesn't need to access the network.

- See https://github.com/nodejs/node/pull/51645