### PR TITLE
Add support for official libc formatting

### DIFF
--- a/lib/detect-libc.js
+++ b/lib/detect-libc.js
@@ -47,7 +47,7 @@ const GLIBC = 'glibc';
  * A Regexp constant to get the GLIBC Version.
  * @type {string}
  */
-const RE_GLIBC_VERSION = /LIBC.*?(\d+\.\d+)/i;
+const RE_GLIBC_VERSION = /LIBC[a-z0-9 \-).]*?(\d+\.\d+)/i;
 
 /**
  * A String constant containing the value `musl`.

--- a/lib/detect-libc.js
+++ b/lib/detect-libc.js
@@ -86,7 +86,7 @@ const getFamilyFromLddContent = (content) => {
   if (content.includes('musl')) {
     return MUSL;
   }
-  if (content.match(/libc/i)) {
+  if (content.includes('GNU C Library')) {
     return GLIBC;
   }
   return null;

--- a/lib/detect-libc.js
+++ b/lib/detect-libc.js
@@ -47,7 +47,7 @@ const GLIBC = 'glibc';
  * A Regexp constant to get the GLIBC Version.
  * @type {string}
  */
-const RE_GLIBC_VERSION = /GLIBC\s(\d+\.\d+)/;
+const RE_GLIBC_VERSION = /LIBC.*?(\d+\.\d+)/i;
 
 /**
  * A String constant containing the value `musl`.
@@ -86,7 +86,7 @@ const getFamilyFromLddContent = (content) => {
   if (content.includes('musl')) {
     return MUSL;
   }
-  if (content.includes('GLIBC')) {
+  if (content.match(/libc/i)) {
     return GLIBC;
   }
   return null;

--- a/test/unit.js
+++ b/test/unit.js
@@ -557,7 +557,7 @@ test('linux - glibc version detected via filesystemSync (libc)', async (t) => {
   t.is(libc.versionSync(), '2.39');
 });
 
-test('linux - glibc version detected via filesystemSync (void linux)', (t) => {
+test('linux - libc version not detected via filesystemSync (void linux musl)', (t) => {
   t.plan(1);
 
   const out = 'startlibc_startGNU AS 2.35.1';

--- a/test/unit.js
+++ b/test/unit.js
@@ -504,6 +504,27 @@ test('linux - glibc version detected via filesystem (libc)', async (t) => {
   t.is(await libc.version(), '2.39');
 });
 
+test('linux - glibc version detected via filesystem (void linux)', async (t) => {
+  t.plan(1);
+
+  const out = 'startlibc_startGNU AS 2.35.1';
+  const libc = proxyquire('../', {
+    './process': {
+      isLinux: () => true,
+      getReport: () => ({})
+    },
+    './filesystem': {
+      readFile: () => Promise.resolve(out)
+    },
+    child_process: {
+      exec: (_c, cb) => cb(null, out),
+      execSync: () => out
+    }
+  });
+
+  t.is(await libc.version(), null);
+});
+
 test('linux - glibc version detected via filesystemSync', async (t) => {
   t.plan(1);
 
@@ -534,6 +555,27 @@ test('linux - glibc version detected via filesystemSync (libc)', async (t) => {
   });
 
   t.is(libc.versionSync(), '2.39');
+});
+
+test('linux - glibc version detected via filesystemSync (void linux)', (t) => {
+  t.plan(1);
+
+  const out = 'startlibc_startGNU AS 2.35.1';
+  const libc = proxyquire('../', {
+    './process': {
+      isLinux: () => true,
+      getReport: () => ({})
+    },
+    './filesystem': {
+      readFile: () => Promise.resolve(out)
+    },
+    child_process: {
+      exec: (_c, cb) => cb(null, out),
+      execSync: () => out
+    }
+  });
+
+  t.is(libc.versionSync(), null);
 });
 
 test('linux - glibc version detected via child process', async (t) => {

--- a/test/unit.js
+++ b/test/unit.js
@@ -58,23 +58,7 @@ test('linux - glibc family detected via ldd', async (t) => {
       isLinux: () => true
     },
     './filesystem': {
-      readFile: () => Promise.resolve('bunch-of-text GLIBC')
-    }
-  });
-
-  t.is(await libc.family(), libc.GLIBC);
-  t.false(await libc.isNonGlibcLinux());
-});
-
-test('linux - glibc family detected via ldd (libc)', async (t) => {
-  t.plan(2);
-
-  const libc = proxyquire('../', {
-    './process': {
-      isLinux: () => true
-    },
-    './filesystem': {
-      readFile: () => Promise.resolve('TEXTDOMAIN=libc')
+      readFile: () => Promise.resolve('# This file is part of the GNU C Library.')
     }
   });
 
@@ -90,23 +74,7 @@ test('linux - glibc familySync detected via ldd', async (t) => {
       isLinux: () => true
     },
     './filesystem': {
-      readFileSync: () => 'bunch-of-text GLIBC'
-    }
-  });
-
-  t.is(libc.familySync(), libc.GLIBC);
-  t.false(libc.isNonGlibcLinuxSync());
-});
-
-test('linux - glibc familySync detected via ldd (libc)', async (t) => {
-  t.plan(2);
-
-  const libc = proxyquire('../', {
-    './process': {
-      isLinux: () => true
-    },
-    './filesystem': {
-      readFileSync: () => 'TEXTDOMAIN=libc'
+      readFileSync: () => '# The GNU C Library is free software; you can redistribute it and/or'
     }
   });
 

--- a/test/unit.js
+++ b/test/unit.js
@@ -66,6 +66,22 @@ test('linux - glibc family detected via ldd', async (t) => {
   t.false(await libc.isNonGlibcLinux());
 });
 
+test('linux - glibc family detected via ldd (libc)', async (t) => {
+  t.plan(2);
+
+  const libc = proxyquire('../', {
+    './process': {
+      isLinux: () => true
+    },
+    './filesystem': {
+      readFile: () => Promise.resolve('TEXTDOMAIN=libc')
+    }
+  });
+
+  t.is(await libc.family(), libc.GLIBC);
+  t.false(await libc.isNonGlibcLinux());
+});
+
 test('linux - glibc familySync detected via ldd', async (t) => {
   t.plan(2);
 
@@ -75,6 +91,22 @@ test('linux - glibc familySync detected via ldd', async (t) => {
     },
     './filesystem': {
       readFileSync: () => 'bunch-of-text GLIBC'
+    }
+  });
+
+  t.is(libc.familySync(), libc.GLIBC);
+  t.false(libc.isNonGlibcLinuxSync());
+});
+
+test('linux - glibc familySync detected via ldd (libc)', async (t) => {
+  t.plan(2);
+
+  const libc = proxyquire('../', {
+    './process': {
+      isLinux: () => true
+    },
+    './filesystem': {
+      readFileSync: () => 'TEXTDOMAIN=libc'
     }
   });
 
@@ -488,6 +520,22 @@ test('linux - glibc version detected via filesystem', async (t) => {
   t.is(await libc.version(), '1.23');
 });
 
+test('linux - glibc version detected via filesystem (libc)', async (t) => {
+  t.plan(1);
+
+  const out = '--vers | --versi | --versio | --version)\necho \'ldd (GNU libc) 2.39\'';
+  const libc = proxyquire('../', {
+    './process': {
+      isLinux: () => true
+    },
+    './filesystem': {
+      readFile: () => Promise.resolve(out)
+    }
+  });
+
+  t.is(await libc.version(), '2.39');
+});
+
 test('linux - glibc version detected via filesystemSync', async (t) => {
   t.plan(1);
 
@@ -502,6 +550,22 @@ test('linux - glibc version detected via filesystemSync', async (t) => {
   });
 
   t.is(libc.versionSync(), '1.23');
+});
+
+test('linux - glibc version detected via filesystemSync (libc)', async (t) => {
+  t.plan(1);
+
+  const out = '--vers | --versi | --versio | --version)\necho \'ldd (GNU libc) 2.39\'';
+  const libc = proxyquire('../', {
+    './process': {
+      isLinux: () => true
+    },
+    './filesystem': {
+      readFileSync: () => out
+    }
+  });
+
+  t.is(libc.versionSync(), '2.39');
 });
 
 test('linux - glibc version detected via child process', async (t) => {

--- a/test/unit.js
+++ b/test/unit.js
@@ -504,7 +504,7 @@ test('linux - glibc version detected via filesystem (libc)', async (t) => {
   t.is(await libc.version(), '2.39');
 });
 
-test('linux - glibc version detected via filesystem (void linux)', async (t) => {
+test('linux - libc version not detected via filesystem (void linux musl)', async (t) => {
   t.plan(1);
 
   const out = 'startlibc_startGNU AS 2.35.1';


### PR DESCRIPTION
This PR updates the ldd content checks for family and version to account for distributions that are more closely aligned with the official formatting of ldd, which [does not contain the string "GLIBC"](https://sourceware.org/git/?p=glibc.git;a=blob;f=elf/ldd.bash.in;h=d6b640df666c5e2d064175c31afa41eb5e63aa3d;hb=HEAD).

This allows faster checks on distros like Amazon Linux, openSUSE, Fedora, RHEL, Arch, and more without falling back to `process.report.getReport()`.