### PR TITLE
Add types field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,6 @@
   },
   "engines": {
     "node": ">=8"
-  }
+  },
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
[NPM](https://www.npmjs.com/package/detect-libc) (the website) doesn't detect the index.d.ts type definition file, and suggests the incorrect (old?) [DefinitelyTyped](https://www.npmjs.com/package/@types/detect-libc) types instead.

I've found a few packages in the wild that incorrectly think the `family` export is a constant based on those incorrect type definitions.

Adding the types field in the package.json should get npm to recognise the correct definitions, which should reduce the number of people reaching for the old and incorrect DefinitelyTyped definitions.