### PR TITLE
Ensure compatibility with Node.js 10 and 12

### DIFF
--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -37,7 +37,7 @@ const readFile = (path) => new Promise((resolve, reject) => {
       const buffer = Buffer.alloc(MAX_LENGTH);
       fs.read(fd, buffer, 0, MAX_LENGTH, 0, (_, bytesRead) => {
         resolve(buffer.subarray(0, bytesRead));
-        fs.close(fd);
+        fs.close(fd, () => {});
       });
     }
   });


### PR DESCRIPTION
In Node.js 10 and 12, `callback` to `fs.close()` is required:
* https://nodejs.org/docs/latest-v12.x/api/fs.html#fs_fs_close_fd_callback
* https://nodejs.org/docs/latest-v10.x/api/fs.html#fs_fs_close_fd_callback

Can be verified using `npm run bench`:
```
ubuntu@ubuntu:/tmp/detect-libc (main) $ node -v
v10.24.1
ubuntu@ubuntu:/tmp/detect-libc (main) $ npm run bench

> detect-libc@2.1.0 bench /tmp/detect-libc
> node benchmark/detect-libc

fs.js:136
    throw new ERR_INVALID_CALLBACK();
    ^

TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
    at makeCallback (fs.js:136:11)
    at Object.close (fs.js:394:20)
    at fs.read (/tmp/detect-libc/lib/filesystem.js:40:12)
    at FSReqWrap.wrapper [as oncomplete] (fs.js:467:17)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! detect-libc@2.1.0 bench: `node benchmark/detect-libc`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the detect-libc@2.1.0 bench script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/ubuntu/.npm/_logs/2025-09-24T13_19_36_624Z-debug.log
```
