### PR TITLE
Ensure compatibility with Node.js 10 and 12 (Fix missed one)

### DIFF
--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -19,7 +19,7 @@ const readFileSync = (path) => {
   const fd = fs.openSync(path, 'r');
   const buffer = Buffer.alloc(MAX_LENGTH);
   const bytesRead = fs.readSync(fd, buffer, 0, MAX_LENGTH, 0);
-  fs.close(fd);
+  fs.close(fd, () => {});
   return buffer.subarray(0, bytesRead);
 };
 


### PR DESCRIPTION
Continuing from [#30](https://github.com/lovell/detect-libc/pull/30):
It seems that one `fs.close()` line still remains.

In my case, [commit 4d6eafec](https://github.com/lovell/detect-libc/commit/4d6eafecb2bd6c45f8a95822966cf7c08f79d21b) caused [denoland/deno#30718](https://github.com/denoland/deno/issues/30718), so this PR should fix it and may also help users affected by that issue on Deno.